### PR TITLE
Don't use the offset for the current local buffer

### DIFF
--- a/src/HexEdit/DlgStrings.c
+++ b/src/HexEdit/DlgStrings.c
@@ -208,7 +208,7 @@ BOOL FindStrings(HWND hwndHV, HWND hwndGV, size_w offset, size_w length, int min
 					size_t l = min(len-i,90);
 					if(endmatch != -1)
 						l = (size_t)min(90,endmatch-startmatch);
-					_stprintf_s(samp, 100, TEXT("%.*hs"), l, buf+i+(startmatch-offset));
+					_stprintf_s(samp, 100, TEXT("%.*hs"), l, buf+i+startmatch);
 				}
 				
 				// did we find the end of the string?


### PR DESCRIPTION
Using the offset in the calculation for the local buffer is leading to
access a wrong memory address and leads to reproducible crashes
when searching for strings. (At least on my machine)
