### PR TITLE
Fix for the typelib auto-update feature

### DIFF
--- a/src/HexEdit/HexEdit.c
+++ b/src/HexEdit/HexEdit.c
@@ -897,8 +897,17 @@ LRESULT HexEdit_OnNotify(MAINWND *mainWnd, HWND hwnd, UINT idCtrl, NMHDR *hdr)
 
 	if (hdr->code == FCN_FILECHANGE)
 	{
-		InitTypeLibrary();
-		UpdateTypeView();
+		NMFILECHANGE *nmfc = (NMFILECHANGE *)hdr;
+		TCHAR szMessage[MAX_PATH + 100];
+		wsprintf(szMessage, TEXT("%s\r\n\r\nThis file has changed outside of the TypeView editor.\r\nDo you want to reload the changes?"), nmfc->pszFile);
+
+		UINT ret = MessageBox(hwnd, szMessage, TEXT("HexEdit"), MB_ICONQUESTION | MB_YESNO);
+
+		if (ret == IDYES)
+		{
+			InitTypeLibrary();
+			UpdateTypeView();
+		}
 		return 0;
 	}
 

--- a/src/HexEdit/HexEdit.c
+++ b/src/HexEdit/HexEdit.c
@@ -21,6 +21,7 @@
 #include "HexFile.h"
 #include "TabView.h"
 #include "RecentFile.h"
+#include "FileChange.h"
 #include "..\DockLib\DockLib.h"
 #include "..\ConfigLib\ConfigLib.h"
 #include "..\TypeView\TypeView.h"
@@ -157,6 +158,7 @@ void LoadSettings();
 void FirstTimeOptions(HWND hwndMain);
 BOOL UpdateHighlights(BOOL fAlways);
 int HexPasteSpecialDlg2(HWND hwnd);
+void InitTypeLibrary();
 
 #pragma comment(lib, "comctl32.lib")
 
@@ -890,6 +892,13 @@ LRESULT HexEdit_OnNotify(MAINWND *mainWnd, HWND hwnd, UINT idCtrl, NMHDR *hdr)
 			break;
 		}
 
+		return 0;
+	}
+
+	if (hdr->code == FCN_FILECHANGE)
+	{
+		InitTypeLibrary();
+		UpdateTypeView();
 		return 0;
 	}
 

--- a/src/TypeView/TypeViewGui.cpp
+++ b/src/TypeView/TypeViewGui.cpp
@@ -1032,7 +1032,7 @@ void GetModuleDirectory(HMODULE hModule, TCHAR *szPath, DWORD nSize)
 }
 
 
-void InitTypeLibrary()
+extern "C" void InitTypeLibrary()
 {
 	TCHAR szPath[MAX_PATH];
 	char path[MAX_PATH];

--- a/src/TypeView/TypeViewWnd.cpp
+++ b/src/TypeView/TypeViewWnd.cpp
@@ -679,17 +679,35 @@ void SaveTypeView(HWND hwndPanel, HKEY hKey)
 
 void FillTypeList(HWND hwndCombo)
 {
+	// Preserve the current selection if possible.
+	char selectedName[MAX_STRING_LEN] = "";
+	int idx;
+
+	idx = SendMessage(hwndCombo, CB_GETCURSEL, 0, 0);
+	if (idx != CB_ERR)
+	{
+		SendMessageA(hwndCombo, CB_GETLBTEXT, idx, (LPARAM)selectedName);
+	}
+
+	SendMessage(hwndCombo, CB_RESETCONTENT, 0, 0);
+	idx = 0;
+
 	for(size_t i = 0; i < globalTagSymbolList.size(); i++)
 	{
 		Symbol *sym = globalTagSymbolList[i];
 
 		if(IsExportedStruct(sym->type) && sym->anonymous == false)
 		{
+			if (selectedName[0] && strcmp(sym->name, selectedName) == 0)
+			{
+				idx = SendMessage(hwndCombo, CB_GETCOUNT, 0, 0);
+				selectedName[0] = 0;
+			}
 			SendMessageA(hwndCombo, CB_ADDSTRING, 0, (LPARAM)sym->name);
 		}
 	}
 
-	SendMessageA(hwndCombo, CB_SETCURSEL, 0, 0);
+	SendMessage(hwndCombo, CB_SETCURSEL, idx, 0);
 }
  
 void SetDefaultType(HWND hwndTypeView)
@@ -926,6 +944,7 @@ void UpdateTypeView()
 		id = l[i];
 		HWND hwndTypeView  = DockWnd_GetContents(g_hwndMain, id);
 		HWND hwndGridView  = GetDlgItem(hwndTypeView, IDC_TYPEVIEW_GRIDVIEW);
+		HWND hwndTypeList = GetDlgItem(hwndTypeView, IDC_TYPEVIEW_TYPECOMBO);
 
 		SetDlgItemBaseInt(hwndTypeView, IDC_TYPEVIEW_ADDRESS, offset, 16, TRUE);
 
@@ -939,6 +958,8 @@ void UpdateTypeView()
 			GetDlgItemTextA(hwndTypeView, IDC_TYPEVIEW_TYPECOMBO, typeName, 100);
 			UpdateTypeGridView(hwndGridView, offset, typeName);
 		}
+
+		FillTypeList(hwndTypeList);
 	}
 
 /**	LARGE_INTEGER freq;

--- a/src/TypeView/TypeViewWnd.cpp
+++ b/src/TypeView/TypeViewWnd.cpp
@@ -601,18 +601,6 @@ LRESULT CALLBACK TypeViewCommandHandler(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 		NMGRIDVIEW *nmgv = (NMGRIDVIEW *)lParam;
 		NMFILECHANGE *nmfc = (NMFILECHANGE *)lParam;
 
-		if(nmfc->hdr.code == FCN_FILECHANGE)
-		{
-			TCHAR szMessage[MAX_PATH+100];
-			wsprintf(szMessage, TEXT("%s\r\n\r\nThis file has changed outside of the TypeView editor.\r\nDo you want to reload the changes?"), nmfc->pszFile);
-
-			UINT ret = MessageBox(hwnd, szMessage, TEXT("HexEdit"), MB_ICONQUESTION|MB_YESNO);
-
-			if(ret == IDYES)
-				UpdateTypeView();
-			return 0;
-		}
-
 		// 
 		if(nmgv->hdr.code == GVN_CANINSERT || nmgv->hdr.code == GVN_CANDELETE)
 		{


### PR DESCRIPTION
Hi James,

This fix makes HexEdit to automatically pick up changes in the typelib files. Looks like this feature was implemented at some point but got broken later.

This patch is cleaner than my previous pull request. It's in a feature branch, and it does not include any build compatibility changes.
