### PR TITLE
Don't attempt to save bookmarks if a file isn't open.

### DIFF
--- a/src/HexEdit/DlgHighlight.c
+++ b/src/HexEdit/DlgHighlight.c
@@ -461,7 +461,8 @@ BOOL SaveHighlights(HWND hwndHexView)
 	HBOOKMARK hbm;
 	HCONFIG config, filedata, bookmarks;
 
-	GetBookmarkFileName(hwndHexView, NULL, szBookPath);
+	if (!GetBookmarkFileName(hwndHexView, NULL, szBookPath))
+		return FALSE;
 
 	config	  = CreateConfig();
 	filedata  = CreateConfigSection(config, TEXT("hexFileData"));


### PR DESCRIPTION
This should fix the gibberish filename problem mentioned in issue #11.